### PR TITLE
BugFix: Do not break if username (loginname) is passed as userid.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix: Do not break if username (loginname) is passed as userid.
+  Like plone.app.discussion does until 2.3.2
+  [mathias.leimgruber]
 
 
 1.0.2 (2014-05-03)

--- a/ftw/avatar/member.py
+++ b/ftw/avatar/member.py
@@ -6,6 +6,18 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 
 
+def get_user_id(userid):
+    portal = getSite()
+    membership = getToolByName(portal, 'portal_membership')
+    member = membership.getMemberById(userid)
+
+    if member is None:
+        acl_users = getToolByName(portal, 'acl_users')
+        user = acl_users.getUser(userid)
+        userid = user.getId()
+    return userid
+
+
 def get_name_of_user(userid):
     portal = getSite()
     membership = getToolByName(portal, 'portal_membership')
@@ -22,6 +34,7 @@ def user_has_portrait(userid):
 
 
 def create_default_avatar(userid):
+    userid = get_user_id(userid)
     if user_has_portrait(userid):
         return
 

--- a/ftw/avatar/tests/test_member.py
+++ b/ftw/avatar/tests/test_member.py
@@ -1,10 +1,13 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.avatar.member import create_default_avatar
 from ftw.avatar.member import get_name_of_user
+from ftw.avatar.member import get_user_id
 from ftw.avatar.testing import AVATAR_FUNCTIONAL_TESTING
 from ftw.builder import Builder
 from ftw.builder import create
 from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 import hashlib
 
@@ -18,6 +21,20 @@ class TestCreateDefaultAvatar(TestCase):
 
     def test_name_of_user_with_no_fullname(self):
         self.assertEquals('admin', get_name_of_user(SITE_OWNER_NAME))
+
+
+    def test_get_user_id_by_username(self):
+        self.assertEquals(TEST_USER_ID, get_user_id(TEST_USER_NAME))
+
+
+    def test_name_of_user_with_different_loginname(self):
+        """Background: Plone sometimes treads username as userid, but it's
+           possible that the username (loginname) differes from the userid.
+           For example plone.discussion is bugy until 2.3.2, it passes the
+           username as userid, which is completly wrong.
+        """
+        self.assertEquals(TEST_USER_ID,
+                          get_name_of_user(get_user_id(TEST_USER_NAME)))
 
     def test_creates_default_avatar_for_users_without_avatar(self):
         hugo = create(Builder('user').named('Hugo', 'Boss'))


### PR DESCRIPTION
Background: Plone sometimes treats username as userid, but it's
possible that the username (loginname) differes from the userid. 
For example plone.discussion is bugy until 2.3.2, it passes the username as userid, which is completly wrong.
