### PR TITLE
Fix error when portrait is stored as Pdata object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error when portrait is stored as Pdata object.
+  [jone]
 
 
 1.0.5 (2015-01-09)

--- a/ftw/avatar/browser/portrait.py
+++ b/ftw/avatar/browser/portrait.py
@@ -1,6 +1,7 @@
-from Products.Five.browser import BrowserView
+from OFS.Image import Pdata
 from plone.scale.scale import scaleImage
 from plone.scale.storage import AnnotationStorage
+from Products.Five.browser import BrowserView
 from webdav.common import rfc1123_date
 from zope.annotation import IAttributeAnnotatable
 from zope.interface import alsoProvides
@@ -33,4 +34,7 @@ class PortraitScalingView(BrowserView):
         return scale['data']
 
     def scale_factory(self, **parameters):
-        return scaleImage(self.context.data, **parameters)
+        portrait = self.context.data
+        if isinstance(portrait, Pdata):
+            portrait = str(portrait)
+        return scaleImage(portrait, **parameters)


### PR DESCRIPTION
Sometimes the portrait is stored as Pdata object instead of as string,
which causes an AttributeError "read" when trying to scale it.

It is unclear why those images are stored differently.
Although it happend with a PNG image, not all PNG images are affected,
nor is it the file size relevant.