### PR TITLE
Fix error when fullname has leading spaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error when fullname has leading spaces.
+  [jone]
 
 
 1.0.6 (2015-03-09)

--- a/ftw/avatar/default.py
+++ b/ftw/avatar/default.py
@@ -43,7 +43,7 @@ class DefaultAvatarGenerator(object):
         if not name:
             return '-'
 
-        words = name.split(' ', 1)
+        words = name.strip().split(' ', 1)
         if len(words) == 1:
             return words[0][:2].upper()
         else:

--- a/ftw/avatar/tests/test_default_generator.py
+++ b/ftw/avatar/tests/test_default_generator.py
@@ -34,3 +34,6 @@ class TestDefaultAvatarGenerator(TestCase):
         self.assertEquals(
             [int, int, int],
             map(type, DefaultAvatarGenerator().background_color()))
+
+    def test_text_with_leading_and_trailing_spaces(self):
+        self.assertEquals('HB', DefaultAvatarGenerator().text(' Hugo Boss '))


### PR DESCRIPTION
Leading spaces in the fullname caused the default avatar generator to crash when splitting the fullname into words.

Closes #8 