### PR TITLE
Changed utility method IAvatarGenerator.generate to take userid instead of full name.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,13 @@ Changelog
 =========
 
 
-1.0.8 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed utility method IAvatarGenerator.generate to take userid instead of full name.
+  This makes the utility more flexible while overwriting because the user can now
+  be identified accurately.
+  [lknoepfel]
 
 
 1.0.7 (2015-09-02)

--- a/ftw/avatar/interfaces.py
+++ b/ftw/avatar/interfaces.py
@@ -5,8 +5,8 @@ class IAvatarGenerator(Interface):
     """Adapter for generating a default avatar.
     """
 
-    def generate(name, output_stream):
+    def generate(userid, output_stream):
         """Generates a default avatar image for a user with the passed
-        ``name`` and writes to the ``output_stream``, which is expected
+        ``userid`` and writes to the ``output_stream``, which is expected
         to be a file-like object.
         """

--- a/ftw/avatar/member.py
+++ b/ftw/avatar/member.py
@@ -1,9 +1,9 @@
-from Products.CMFCore.utils import getToolByName
-from StringIO import StringIO
 from ftw.avatar.interfaces import IAvatarGenerator
 from ftw.avatar.utils import SwitchedToSystemUser
-from zope.component import getUtility
+from Products.CMFCore.utils import getToolByName
+from StringIO import StringIO
 from zope.component.hooks import getSite
+from zope.component import getUtility
 
 
 def get_user_id(userid):
@@ -22,15 +22,6 @@ def get_user_id(userid):
     return None
 
 
-def get_name_of_user(userid):
-    portal = getSite()
-    membership = getToolByName(portal, 'portal_membership')
-    member = membership.getMemberById(userid)
-    if not member:
-        return userid
-    return member.getProperty('fullname', None) or userid
-
-
 def user_has_portrait(userid):
     portal = getSite()
     membership = getToolByName(portal, 'portal_membership')
@@ -46,7 +37,7 @@ def create_default_avatar(userid):
 
     portrait = StringIO()
     generator = getUtility(IAvatarGenerator)
-    if not generator.generate(get_name_of_user(userid), portrait):
+    if not generator.generate(userid, portrait):
         return
     portrait.seek(0)
     setattr(portrait, 'filename', 'default.png')

--- a/ftw/avatar/tests/test_default_generator.py
+++ b/ftw/avatar/tests/test_default_generator.py
@@ -1,26 +1,44 @@
+from ftw.avatar.default import DefaultAvatarGenerator
+from ftw.avatar.testing import AVATAR_FUNCTIONAL_TESTING
+from ftw.builder import Builder
+from ftw.builder import create
 from PIL import Image
 from StringIO import StringIO
-from ftw.avatar.default import DefaultAvatarGenerator
 from unittest2 import TestCase
+from zope.component.hooks import getSite
 
 
 class TestDefaultAvatarGenerator(TestCase):
+    layer = AVATAR_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestDefaultAvatarGenerator, self).setUp()
+        self.portal_membership = getSite().portal_membership
 
     def test_generates_220x220_image(self):
+        user = create(Builder('user').named('Hugo', 'Boss'))
         output = StringIO()
-        DefaultAvatarGenerator().generate('Foo Bar', output)
+        DefaultAvatarGenerator().generate(user.getId(), output)
         output.seek(0)
         self.assertEquals((220, 220), Image.open(output).size)
 
     def test_text_is_capital_first_letters_of_first_two_words(self):
-        self.assertEquals('FB', DefaultAvatarGenerator().text('Foo bar'))
-        self.assertEquals('AB', DefaultAvatarGenerator().text('Aaa Bbb Ccc'))
+        user = create(Builder('user').named('Foo', 'Bar'))
+        user2 = create(Builder('user').named('Foo', 'Goo Poo'))
+        self.assertEquals('BF', DefaultAvatarGenerator().text(user.getId()))
+        self.assertEquals('GP', DefaultAvatarGenerator().text(user2.getId()))
 
     def test_text_is_two_letters_of_word_when_only_one_word_given(self):
-        self.assertEquals('FO', DefaultAvatarGenerator().text('Foo'))
+        user = create(Builder('user').named('Foo', 'Bar'))
+        member = self.portal_membership.getMemberById(user.getId())
+        member.setMemberProperties(mapping={"fullname": "Foo"})
+        self.assertEquals('FO', DefaultAvatarGenerator().text(user.getId()))
 
     def test_text_is_only_one_letter(self):
-        self.assertEquals('X', DefaultAvatarGenerator().text('x'))
+        user = create(Builder('user').named('Foo', 'Bar'))
+        member = self.portal_membership.getMemberById(user.getId())
+        member.setMemberProperties(mapping={"fullname": "x"})
+        self.assertEquals('X', DefaultAvatarGenerator().text(user.getId()))
 
     def test_text_is_dash_if_no_names_defined(self):
         self.assertEquals('-', DefaultAvatarGenerator().text(None))
@@ -36,4 +54,16 @@ class TestDefaultAvatarGenerator(TestCase):
             map(type, DefaultAvatarGenerator().background_color()))
 
     def test_text_with_leading_and_trailing_spaces(self):
-        self.assertEquals('HB', DefaultAvatarGenerator().text(' Hugo Boss '))
+        user = create(Builder('user').named('Foo', 'Bar'))
+        member = self.portal_membership.getMemberById(user.getId())
+        member.setMemberProperties(mapping={"fullname": " Hugo Boss "})
+        self.assertEquals('HB', DefaultAvatarGenerator().text(user.getId()))
+
+    def test_text_of_user_without_fullname_is_userid(self):
+        self.assertEquals('AD', DefaultAvatarGenerator().text('admin'))
+
+    def test_text_of_non_existent_user(self):
+        self.assertEquals('UN', DefaultAvatarGenerator().text('unkown.user'))
+
+    def test_text_of_non_existent_user_with_leading_spaces(self):
+        self.assertEquals('UU', DefaultAvatarGenerator().text('  unkown user  '))

--- a/ftw/avatar/tests/test_member.py
+++ b/ftw/avatar/tests/test_member.py
@@ -1,10 +1,8 @@
 from ftw.avatar.member import create_default_avatar
-from ftw.avatar.member import get_name_of_user
 from ftw.avatar.member import get_user_id
 from ftw.avatar.testing import AVATAR_FUNCTIONAL_TESTING
 from ftw.builder import Builder
 from ftw.builder import create
-from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from Products.CMFCore.utils import getToolByName
@@ -15,30 +13,11 @@ import hashlib
 class TestCreateDefaultAvatar(TestCase):
     layer = AVATAR_FUNCTIONAL_TESTING
 
-    def test_name_of_user(self):
-        user = create(Builder('user').named('Hugo', 'Boss'))
-        self.assertEquals('Boss Hugo', get_name_of_user(user.getId()))
-
-    def test_name_of_user_with_no_fullname(self):
-        self.assertEquals('admin', get_name_of_user(SITE_OWNER_NAME))
-
     def test_get_user_id_by_username(self):
         self.assertEquals(TEST_USER_ID, get_user_id(TEST_USER_NAME))
 
     def test_get_user_id_of_unkown_user(self):
         self.assertEquals(None, get_user_id('unkown'))
-
-    def test_name_of_user_with_different_loginname(self):
-        """Background: Plone sometimes treads username as userid, but it's
-           possible that the username (loginname) differes from the userid.
-           For example plone.discussion is bugy until 2.3.2, it passes the
-           username as userid, which is completly wrong.
-        """
-        self.assertEquals(TEST_USER_ID,
-                          get_name_of_user(get_user_id(TEST_USER_NAME)))
-
-    def test_get_name_of_user_which_does_not_exist(self):
-        self.assertEquals('unkown.user', get_name_of_user('unkown.user'))
 
     def test_creates_default_avatar_for_users_without_avatar(self):
         hugo = create(Builder('user').named('Hugo', 'Boss'))


### PR DESCRIPTION
This makes the utility more flexible while overwriting because the user can now be identified accurately.

My use-case is to take a custom property on the member object and generate an icon from that.
This is currently not possible because ftw.avatar passes the `fullname` to the `IAvatarGenerator.generate` method. I can't safely identify the user with this information.

This PR moves the functionality to generate an avatar from the `fullname` entirely into the default implementation. This allows a products to override this and use entirely different user information to generate the icon.