### PR TITLE
Disable CSRF protection for default avatar creation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable CSRF protection for default avatar creation. [phgross]
 
 
 2.0.1 (2016-08-12)

--- a/ftw/avatar/member.py
+++ b/ftw/avatar/member.py
@@ -2,8 +2,18 @@ from ftw.avatar.interfaces import IAvatarGenerator
 from ftw.avatar.utils import SwitchedToSystemUser
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
-from zope.component.hooks import getSite
 from zope.component import getUtility
+from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+
+
+try:
+    from plone.protect.interfaces import IDisableCSRFProtection
+except ImportError:
+    DISABLE_CSRF = False
+else:
+    DISABLE_CSRF = True
 
 
 def get_user_id(userid):
@@ -45,4 +55,7 @@ def create_default_avatar(userid):
     portal = getSite()
     membership = getToolByName(portal, 'portal_membership')
     with SwitchedToSystemUser():
+        if DISABLE_CSRF:
+            alsoProvides(getRequest(), IDisableCSRFProtection)
+
         membership.changeMemberPortrait(portrait, id=userid)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'plone.app.testing',
+    'plone.protect',
     'transaction',
     'unittest2',
     'zope.configuration',


### PR DESCRIPTION
🚧 Wait - should no longer be necessary with #16 🚧 

The default avatar creation is done on the first access of the portrait image, which is not guaranteed an POST requests, therefore we need to disable the CSRF protection for the default avatar generation.

The `plone.protect` imports are conditionally, so it should still work with older plone.protect packages.