### PR TITLE
Avoid writes on read - create default avatar on login.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.0.2 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid writes on read - create default avatar on login instead of on portrait
+  access. [phgross]
 
 
 2.0.1 (2016-08-12)

--- a/ftw/avatar/configure.zcml
+++ b/ftw/avatar/configure.zcml
@@ -7,4 +7,9 @@
     <utility factory=".default.DefaultAvatarGenerator"
              provides="ftw.avatar.interfaces.IAvatarGenerator" />
 
+    <subscriber
+      for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"
+      handler=".handlers.check_avatar"
+    />
+
 </configure>

--- a/ftw/avatar/handlers.py
+++ b/ftw/avatar/handlers.py
@@ -1,0 +1,5 @@
+from ftw.avatar.member import create_default_avatar
+
+
+def check_avatar(event):
+    create_default_avatar(event.principal.getId())

--- a/ftw/avatar/patches.py
+++ b/ftw/avatar/patches.py
@@ -1,4 +1,3 @@
-from ftw.avatar.member import create_default_avatar
 from ftw.avatar import LOGGER
 
 MEMBER_IMAGE_SCALE = (300, 300)
@@ -6,7 +5,6 @@ MEMBER_IMAGE_SCALE = (300, 300)
 
 def apply_patches():
     apply_member_image_scale_patch()
-    apply_getPersonalPortrait_patch()
 
 
 def apply_member_image_scale_patch():
@@ -15,17 +13,3 @@ def apply_member_image_scale_patch():
     from Products.PlonePAS import config
     config.MEMBER_IMAGE_SCALE = MEMBER_IMAGE_SCALE
     config.IMAGE_SCALE_PARAMS['scale'] = MEMBER_IMAGE_SCALE
-
-
-def apply_getPersonalPortrait_patch():
-    LOGGER.info('Patching Products.PlonePAS.tools.membership.MembershipTool'
-                '.getPersonalPortrait for generating a default portrait')
-    from Products.PlonePAS.tools.membership import MembershipTool
-    getPersonalPortrait = MembershipTool.getPersonalPortrait
-
-    def getPersonalPortraitWrapper(self, id=None, verifyPermission=0):
-        create_default_avatar(id or self.getAuthenticatedMember().getId())
-        return getPersonalPortrait(self, id=id,
-                                   verifyPermission=verifyPermission)
-
-    MembershipTool.getPersonalPortrait = getPersonalPortraitWrapper

--- a/ftw/avatar/tests/test_generates_avatars.py
+++ b/ftw/avatar/tests/test_generates_avatars.py
@@ -1,25 +1,34 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.avatar.testing import AVATAR_FUNCTIONAL_TESTING
 from ftw.builder import Builder
 from ftw.builder import create
+from Products.CMFCore.utils import getToolByName
+from Products.PlonePAS.events import UserLoggedInEvent
 from unittest2 import TestCase
+from zope.event import notify
 
 
 class TestAutomaticalAvatarGeneration(TestCase):
     layer = AVATAR_FUNCTIONAL_TESTING
 
-    def test_avatar_is_generated_for_new_users(self):
+    def test_avatar_is_generated_for_new_users_on_login(self):
         hugo = create(Builder('user').named('Hugo', 'Boss'))
         mtool = getToolByName(self.layer['portal'], 'portal_membership')
-        portrait = mtool.getPersonalPortrait(hugo.getId())
+        self.assertEquals(
+            'http://nohost/plone/defaultUser.png',
+            mtool.getPersonalPortrait(hugo.getId()).absolute_url())
+
+        notify(UserLoggedInEvent(hugo))
+
         self.assertEquals(
             'http://nohost/plone/portal_memberdata/portraits/hugo.boss',
-            portrait.absolute_url())
+            mtool.getPersonalPortrait(hugo.getId()).absolute_url())
 
     def test_effective_default_avatar_size(self):
         # When setting the portrait, some scaling is involed.
         # Verify that we actually have a big avatar available.
         hugo = create(Builder('user').named('Hugo', 'Boss'))
+        notify(UserLoggedInEvent(hugo))
+
         mtool = getToolByName(self.layer['portal'], 'portal_membership')
         portrait = mtool.getPersonalPortrait(hugo.getId())
         self.assertEquals((220, 220),

--- a/ftw/avatar/tests/test_portrait_scaling_view.py
+++ b/ftw/avatar/tests/test_portrait_scaling_view.py
@@ -8,9 +8,11 @@ from ftw.testbrowser import browsing
 from OFS.Image import Pdata
 from PIL import Image
 from Products.CMFCore.utils import getToolByName
+from Products.PlonePAS.events import UserLoggedInEvent
 from StringIO import StringIO
 from unittest2 import TestCase
 from zope.component import getUtility
+from zope.event import notify
 import hashlib
 import transaction
 
@@ -29,6 +31,7 @@ class TestPortraitScalingView(TestCase):
 
     def setUp(self):
         self.hugo = create(Builder('user').named('Hugo', 'Boss'))
+        notify(UserLoggedInEvent(self.hugo))
         self.mtool = getToolByName(self.layer['portal'], 'portal_membership')
         self.portrait = self.mtool.getPersonalPortrait(self.hugo.getId())
         self.portrait_url = self.portrait.absolute_url()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-version = '2.0.2.dev0'
+version = '2.1.0.dev0'
 
 
 tests_require = [


### PR DESCRIPTION
To prevent "writes on read", I want to change the behavior of ftw.avatar. Instead of creating the default avatar on the portrait access, the avatar gets created after a successful login.

With a few exceptions, this should change very little for the user. Only if avatars are displayed by users who have never logged in before.

With this change #15 is no longer necessary ...

@maethu @jone what do you think of that? Can you live with this change in your projects?